### PR TITLE
Enable syntax highlighting for example code in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Features:
 
 # Usage
 
-```
+```go
 package main
 
 import (


### PR DESCRIPTION
This is a very minor thing I noticed.