### PR TITLE
Fix miscounting childrenNum in node16's shrink

### DIFF
--- a/node.go
+++ b/node.go
@@ -691,7 +691,9 @@ func (an *artNode) shrink() *artNode {
 				node4.present[i] = 1
 			}
 			node4.children[i] = node16.children[i]
-			node4.numChildren++
+			if node16.children[i] != nil {
+				node4.numChildren++
+			}
 		}
 
 		node4.zeroChild = node16.zeroChild

--- a/tree_test.go
+++ b/tree_test.go
@@ -986,6 +986,31 @@ func TestTreeInsertAndDeleteAllUUIDs(t *testing.T) {
 	assert.Nil(t, tree.root)
 }
 
+func TestTreeInsertAndDeleteConcerningZeroChild(t *testing.T) {
+	keys := []Key{
+		Key("test/a1"),
+		Key("test/a2"),
+		Key("test/a3"),
+		Key("test/a4"),
+		// This should become zeroChild
+		Key("test/a"),
+	}
+
+	tree := newTree()
+	for _, w := range keys {
+		tree.Insert(w, w)
+	}
+
+	for _, w := range keys {
+		v, deleted := tree.Delete(w)
+		assert.True(t, deleted)
+		assert.Equal(t, w, v)
+	}
+
+	assert.Equal(t, 0, tree.size)
+	assert.Nil(t, tree.root)
+}
+
 func TestTreeAPI(t *testing.T) {
 	// test empty tree
 	tree := New()


### PR DESCRIPTION
When keys are added and deleted in order as shown below:

```go
	keys := []Key{
		Key("test/a1"),
		Key("test/a2"),
		Key("test/a3"),
		Key("test/a4"),
		// This should become zeroChild
		Key("test/a"),
	}

	tree := newTree()
	for _, w := range keys {
		tree.Insert(w, w)
	}

	for _, w := range keys {
		// Fail!!!
		tree.Delete(w)
	}
```

This `Delete` will fail:

```
--- FAIL: TestTreeInsertAndDeleteConcerningZeroChild (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x8 pc=0x1046a50ac]

goroutine 92 [running]:
testing.tRunner.func1.2({0x10473d020, 0x10489e010})
        /opt/homebrew/Cellar/go/1.21.1/libexec/src/testing/testing.go:1545 +0x1c8
testing.tRunner.func1()
        /opt/homebrew/Cellar/go/1.21.1/libexec/src/testing/testing.go:1548 +0x360
panic({0x10473d020?, 0x10489e010?})
        /opt/homebrew/Cellar/go/1.21.1/libexec/src/runtime/panic.go:914 +0x218
github.com/plar/go-adaptive-radix-tree.(*artNode).isLeaf(...)
        /opt/go/github.com/plar/go-adaptive-radix-tree/node.go:108
github.com/plar/go-adaptive-radix-tree.(*artNode).shrink(0x14001be5760)
        /opt/go/github.com/plar/go-adaptive-radix-tree/node.go:656 +0x4c
github.com/plar/go-adaptive-radix-tree.(*artNode).deleteChild(0x14001be5760, 0x90?, 0x0?)
        /opt/go/github.com/plar/go-adaptive-radix-tree/node.go:563 +0xcc
github.com/plar/go-adaptive-radix-tree.(*tree).recursiveDelete(0x140000e5ec8, 0x1046b5cfc?, {0x140000b0090, 0x6, 0x6}, 0x0?)
        /opt/go/github.com/plar/go-adaptive-radix-tree/tree.go:218 +0x1f0
github.com/plar/go-adaptive-radix-tree.(*tree).Delete(0x140000e5ec8, {0x140000b0090?, 0x10473e000?, 0x14001c15320?})
        /opt/go/github.com/plar/go-adaptive-radix-tree/tree.go:25 +0x40
github.com/plar/go-adaptive-radix-tree.TestTreeInsertAndDeleteConcerningZeroChild(0x0?)
        /opt/go/github.com/plar/go-adaptive-radix-tree/tree_test.go:1005 +0x208
testing.tRunner(0x140001561a0, 0x10476f3f0)
        /opt/homebrew/Cellar/go/1.21.1/libexec/src/testing/testing.go:1595 +0xe8
created by testing.(*T).Run in goroutine 1
        /opt/homebrew/Cellar/go/1.21.1/libexec/src/testing/testing.go:1648 +0x33c
```

This is because of miscounting of `childrenNum`, so this pull request addresses the issue with childrenNum.

Specifically, when node16 is shrunk to node4, the numChildren value is incorrectly fixed to 4, even though the target node may have between 1 and 3 children (see the example above). This has been corrected when we ensure the `artNode` is not `nil` in iteration.