### PR TITLE
fix: module path should reflect v2 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ package main
 
 import (
     "fmt"
-    "github.com/plar/go-adaptive-radix-tree"
+    "github.com/plar/go-adaptive-radix-tree/v2"
 )
 
 func main() {

--- a/doc.go
+++ b/doc.go
@@ -9,7 +9,7 @@
 //
 //	import (
 //	   "fmt"
-//	   "github.com/plar/go-adaptive-radix-tree"
+//	   "github.com/plar/go-adaptive-radix-tree/v2"
 //	)
 //
 //	func main() {

--- a/examples/gtree/gtree.go
+++ b/examples/gtree/gtree.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	art "github.com/plar/go-adaptive-radix-tree"
+	art "github.com/plar/go-adaptive-radix-tree/v2"
 )
 
 // GTree is a generic tree that supports any type for keys and values.

--- a/examples/gtree/main.go
+++ b/examples/gtree/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	art "github.com/plar/go-adaptive-radix-tree"
+	art "github.com/plar/go-adaptive-radix-tree/v2"
 )
 
 func main() {

--- a/examples/tree.go
+++ b/examples/tree.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	art "github.com/plar/go-adaptive-radix-tree"
+	art "github.com/plar/go-adaptive-radix-tree/v2"
 )
 
 func DumpTree() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/plar/go-adaptive-radix-tree
+module github.com/plar/go-adaptive-radix-tree/v2
 
 go 1.18
 


### PR DESCRIPTION
The new major version, 2.0.0, has been released (https://github.com/plar/go-adaptive-radix-tree/releases/tag/v2.0.0) but does not include an update to the module path in `go.mod` as described [here](https://go.dev/doc/modules/release-workflow#breaking).

I believe this is the reason [pkg.go.dev hasn't picked up the v2 release](https://pkg.go.dev/github.com/plar/go-adaptive-radix-tree?tab=versions) and also why the v2 release cannot be imported in new projects.